### PR TITLE
Basic state machine validator app

### DIFF
--- a/src/org/ggp/base/apps/validator/StateMachineValidator.java
+++ b/src/org/ggp/base/apps/validator/StateMachineValidator.java
@@ -1,0 +1,100 @@
+package org.ggp.base.apps.validator;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.ggp.base.util.game.GameRepository;
+import org.ggp.base.util.game.LocalGameRepository;
+import org.ggp.base.util.gdl.grammar.Gdl;
+import org.ggp.base.util.logging.GamerLogger;
+import org.ggp.base.util.statemachine.StateMachine;
+import org.ggp.base.util.statemachine.implementation.prover.ProverStateMachine;
+import org.ggp.base.util.statemachine.verifier.StateMachineVerifier;
+
+
+/**
+ * 
+ * @author Steve Draper
+ *
+ */
+public class StateMachineValidator {
+	public static void main(String args[]) throws InterruptedException {
+	    Set<String> exceptedGames = new HashSet<String>(); 
+	    
+	    //	Set of games to omit from tests - e.g. - due to known GDL issues
+	    //exceptedGames.add("merrills");
+	    
+	    String startGame = "wargame02";	//	Game to begin with if desired
+	    boolean foundStartGame = false;	//	Set to true to just start at the beginning
+	    boolean stopOnError = true;		//	Whether to stop on first failing game or continue
+	    
+	    Set<String> failureCases = new HashSet<String>();
+	    
+	    //	Usually we'll want the default repository but local can be useful
+        //GameRepository theRepository = new LocalGameRepository();
+        GameRepository theRepository = GameRepository.getDefaultRepository();
+        try
+        {
+	        for(String gameKey : theRepository.getGameKeys()) {
+	            StateMachine theReference = new ProverStateMachine();
+	            //	Instantiate the statemachine to be tested here as per the following commented out
+	            //	line in place of the basic prover
+	            //TestPropnetStateMachine theMachine = new TestPropnetStateMachine();	    
+	            StateMachine theMachine = new ProverStateMachine();	    
+	    	    
+	            System.out.println("Precheck game " + gameKey + ".");
+	            if (gameKey.equals(startGame))
+	            {
+	            	foundStartGame = true;
+	            }
+	            if ( !foundStartGame)
+	            	continue;
+	            if(exceptedGames.contains(gameKey)) continue;
+	            System.out.println("Checking consistency in game " + gameKey + ".");
+	            List<Gdl> description = theRepository.getGame(gameKey).getRules();
+	            theReference.initialize(description);
+	            theMachine.initialize(description);
+
+                boolean result = false;
+                
+                try
+                {
+					result = StateMachineVerifier.checkMachineConsistency(theReference, theMachine, 10000);
+				} catch (Exception e)
+				{
+                    GamerLogger.logStackTrace("StateMachine", e);
+					// TODO: handle exception
+					result = false;
+				}
+	            if ( !result )
+	            {
+	            	failureCases.add(gameKey);
+	            	
+	            	if ( stopOnError )
+	            		break;
+	            }
+	        }
+	        
+	        for(String failure : failureCases)
+	        {
+	            System.out.println("Failed in game " + failure);
+	        }
+        }
+        finally
+        {
+        	//	The local repository suffers from a lack of releasing its port binding
+        	//	under certain execution conditions (debug under Eclipse), so do it
+        	//	explicitly to leave things in a clean state
+        	if (theRepository instanceof LocalGameRepository)
+        	{
+        		((LocalGameRepository)theRepository).cleanUp();
+        	}
+        }
+	}	
+}

--- a/src/org/ggp/base/util/game/LocalGameRepository.java
+++ b/src/org/ggp/base/util/game/LocalGameRepository.java
@@ -47,7 +47,16 @@ public final class LocalGameRepository extends GameRepository {
                 throw new RuntimeException(e);
             }
         }
+        
         theRealRepo = new RemoteGameRepository(theLocalRepoURL);
+    }
+   
+    public void cleanUp()
+    {
+        if (theLocalRepoServer != null) {
+        	theLocalRepoServer.stop(0);
+        }
+   	
     }
     
     @Override


### PR DESCRIPTION
Simple test app that enumerates games from a repository, and runs state
machine validation against each one.  Needs to be manually edited to
instantiate the state machine class you want to test.
Also includes a resource cleanup routine for the local repository to get
around port bindings not being released when running under Eclipse
