### PR TITLE
Improve validator warning handling; add new warning to StaticValidator.

### DIFF
--- a/src/org/ggp/base/apps/validator/BatchValidator.java
+++ b/src/org/ggp/base/apps/validator/BatchValidator.java
@@ -1,5 +1,7 @@
 package org.ggp.base.apps.validator;
 
+import java.util.List;
+
 import org.ggp.base.util.game.CloudGameRepository;
 import org.ggp.base.util.game.Game;
 import org.ggp.base.util.game.GameRepository;
@@ -9,6 +11,9 @@ import org.ggp.base.validator.OPNFValidator;
 import org.ggp.base.validator.SimulationValidator;
 import org.ggp.base.validator.StaticValidator;
 import org.ggp.base.validator.ValidatorException;
+import org.ggp.base.validator.ValidatorWarning;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * BatchValidator does game validation on all of the games in a given game repository.
@@ -35,9 +40,10 @@ public final class BatchValidator
 			System.out.print(gameKey + " ... ");
 			System.out.flush();
 			boolean isValid = true;
+			List<ValidatorWarning> warnings = ImmutableList.of();
 			for (GameValidator theValidator : theValidators) {
 				try {
-					theValidator.checkValidity(game);
+					warnings = theValidator.checkValidity(game);
 				} catch (ValidatorException ve) {
 					System.out.println("Failed: " + ve);
 					isValid = false;
@@ -45,7 +51,11 @@ public final class BatchValidator
 				}
 			}
 			if (isValid) {
-				System.out.println("Passed!");
+				if (warnings.isEmpty()) {
+					System.out.println("Passed!");
+				} else {
+					System.out.println("Passed with warnings: " + warnings);
+				}
 			}
 		}
 	}

--- a/src/org/ggp/base/apps/validator/OutcomePanel.java
+++ b/src/org/ggp/base/apps/validator/OutcomePanel.java
@@ -3,6 +3,7 @@ package org.ggp.base.apps.validator;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.util.List;
 
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
@@ -15,6 +16,7 @@ import org.ggp.base.apps.validator.event.ValidatorSuccessEvent;
 import org.ggp.base.util.observer.Event;
 import org.ggp.base.util.observer.Observer;
 import org.ggp.base.util.ui.table.JZebraTable;
+import org.ggp.base.validator.ValidatorWarning;
 
 @SuppressWarnings("serial")
 public final class OutcomePanel extends JPanel implements Observer
@@ -89,7 +91,12 @@ public final class OutcomePanel extends JPanel implements Observer
 		DefaultTableModel model = (DefaultTableModel) logTable.getModel();
 		int numRows = model.getRowCount() + 1;
 
-		model.addRow(new String[] { event.getName(), "Success!" });
+		List<ValidatorWarning> warnings = event.getWarnings();
+		if (warnings.isEmpty()) {
+			model.addRow(new String[] { event.getName(), "Success!" });
+		} else {
+			model.addRow(new String[] { event.getName(), wrapLine("Success, with warnings: " + warnings, 100) });
+		}
 		progressBar.setValue(numRows);
 	}
 

--- a/src/org/ggp/base/apps/validator/ValidatorThread.java
+++ b/src/org/ggp/base/apps/validator/ValidatorThread.java
@@ -11,6 +11,7 @@ import org.ggp.base.util.observer.Observer;
 import org.ggp.base.util.observer.Subject;
 import org.ggp.base.validator.GameValidator;
 import org.ggp.base.validator.ValidatorException;
+import org.ggp.base.validator.ValidatorWarning;
 
 public final class ValidatorThread extends Thread implements Subject
 {
@@ -44,8 +45,8 @@ public final class ValidatorThread extends Thread implements Subject
 	public void run()
 	{
 		try {
-			theValidator.checkValidity(theGame);
-			notifyObservers(new ValidatorSuccessEvent(theValidator.getClass().getSimpleName()));
+			List<ValidatorWarning> warnings = theValidator.checkValidity(theGame);
+			notifyObservers(new ValidatorSuccessEvent(theValidator.getClass().getSimpleName(), warnings));
 		} catch (ValidatorException ve) {
 			notifyObservers(new ValidatorFailureEvent(theValidator.getClass().getSimpleName(), ve));
 		}

--- a/src/org/ggp/base/apps/validator/event/ValidatorSuccessEvent.java
+++ b/src/org/ggp/base/apps/validator/event/ValidatorSuccessEvent.java
@@ -1,18 +1,27 @@
 package org.ggp.base.apps.validator.event;
 
+import java.util.List;
+
 import org.ggp.base.util.observer.Event;
+import org.ggp.base.validator.ValidatorWarning;
 
 public final class ValidatorSuccessEvent extends Event
 {
 	private final String name;
+	private final List<ValidatorWarning> warnings;
 
-	public ValidatorSuccessEvent(String name)
+	public ValidatorSuccessEvent(String name, List<ValidatorWarning> warnings)
 	{
 		this.name = name;
+		this.warnings = warnings;
 	}
 
 	public String getName()
 	{
 		return name;
+	}
+
+	public List<ValidatorWarning> getWarnings() {
+		return warnings;
 	}
 }

--- a/src/org/ggp/base/validator/BasesInputsValidator.java
+++ b/src/org/ggp/base/validator/BasesInputsValidator.java
@@ -23,6 +23,8 @@ import org.ggp.base.util.statemachine.exceptions.MoveDefinitionException;
 import org.ggp.base.util.statemachine.exceptions.TransitionDefinitionException;
 import org.ggp.base.util.statemachine.implementation.prover.ProverStateMachine;
 
+import com.google.common.collect.ImmutableList;
+
 
 public class BasesInputsValidator implements GameValidator {
 	private static final GdlConstant BASE = GdlPool.getConstant("base");
@@ -38,7 +40,7 @@ public class BasesInputsValidator implements GameValidator {
 	}
 
 	@Override
-	public void checkValidity(Game theGame) throws ValidatorException {
+	public List<ValidatorWarning> checkValidity(Game theGame) throws ValidatorException {
 		try {
 			StateMachine sm = new ProverStateMachine();
 			sm.initialize(theGame.getRules());
@@ -65,7 +67,7 @@ public class BasesInputsValidator implements GameValidator {
 			}
 
 			if (truesFromBases.isEmpty() && legalsFromInputs.isEmpty()) {
-				return;
+				return ImmutableList.of();
 			}
 
 			MachineState initialState = sm.getInitialState();
@@ -114,6 +116,7 @@ public class BasesInputsValidator implements GameValidator {
 		} catch (OutOfMemoryError e) {
 			throw new ValidatorException("Ran out of memory while simulating: " + e);
 		}
+		return ImmutableList.of();
 	}
 
 	/**

--- a/src/org/ggp/base/validator/GameValidator.java
+++ b/src/org/ggp/base/validator/GameValidator.java
@@ -1,7 +1,9 @@
 package org.ggp.base.validator;
 
+import java.util.List;
+
 import org.ggp.base.util.game.Game;
 
 public interface GameValidator {
-	public void checkValidity(Game theGame) throws ValidatorException;
+	public List<ValidatorWarning> checkValidity(Game theGame) throws ValidatorException;
 }

--- a/src/org/ggp/base/validator/OPNFValidator.java
+++ b/src/org/ggp/base/validator/OPNFValidator.java
@@ -2,14 +2,17 @@ package org.ggp.base.validator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.List;
 
 import org.ggp.base.util.game.Game;
 import org.ggp.base.util.propnet.factory.OptimizingPropNetFactory;
 
+import com.google.common.collect.ImmutableList;
+
 public final class OPNFValidator implements GameValidator
 {
 	@Override
-	public void checkValidity(Game theGame) throws ValidatorException {
+	public List<ValidatorWarning> checkValidity(Game theGame) throws ValidatorException {
         PrintStream stdout = System.out;
         System.setOut(new PrintStream(new ByteArrayOutputStream()));
 		try {
@@ -21,5 +24,6 @@ public final class OPNFValidator implements GameValidator
 		} finally {
 	        System.setOut(stdout);
 		}
+		return ImmutableList.of();
 	}
 }

--- a/src/org/ggp/base/validator/SimulationValidator.java
+++ b/src/org/ggp/base/validator/SimulationValidator.java
@@ -1,5 +1,7 @@
 package org.ggp.base.validator;
 
+import java.util.List;
+
 import org.ggp.base.util.game.Game;
 import org.ggp.base.util.statemachine.MachineState;
 import org.ggp.base.util.statemachine.StateMachine;
@@ -7,6 +9,8 @@ import org.ggp.base.util.statemachine.exceptions.GoalDefinitionException;
 import org.ggp.base.util.statemachine.exceptions.MoveDefinitionException;
 import org.ggp.base.util.statemachine.exceptions.TransitionDefinitionException;
 import org.ggp.base.util.statemachine.implementation.prover.ProverStateMachine;
+
+import com.google.common.collect.ImmutableList;
 
 public final class SimulationValidator implements GameValidator
 {
@@ -20,7 +24,7 @@ public final class SimulationValidator implements GameValidator
 	}
 
 	@Override
-	public void checkValidity(Game theGame) throws ValidatorException {
+	public List<ValidatorWarning> checkValidity(Game theGame) throws ValidatorException {
 		for (int i = 0; i < numSimulations; i++) {
 			StateMachine stateMachine = new ProverStateMachine();
 			stateMachine.initialize(theGame.getRules());
@@ -45,5 +49,6 @@ public final class SimulationValidator implements GameValidator
 				throw new ValidatorException("Could not find goals while simulating: " + gde);
 			}
 		}
+		return ImmutableList.of();
 	}
 }

--- a/src/org/ggp/base/validator/ValidatorWarning.java
+++ b/src/org/ggp/base/validator/ValidatorWarning.java
@@ -1,0 +1,14 @@
+package org.ggp.base.validator;
+
+public class ValidatorWarning {
+	private final String warningMessage;
+
+	public ValidatorWarning(String warningMessage) {
+		this.warningMessage = warningMessage;
+	}
+
+	@Override
+	public String toString() {
+		return warningMessage;
+	}
+}


### PR DESCRIPTION
Warnings can now be accumulated and recorded, then shown to the user,
instead of being println'd immediately.

The new StaticValidator warning checks for the use of a constant as both
a sentence and function in a game description. This isn't clearly
prohibited by the GDL specification, but is generally a bad idea.
