### PR TITLE
Fix a bug in the GdlCleaner.

### DIFF
--- a/src/org/ggp/base/util/gdl/transforms/GdlCleaner.java
+++ b/src/org/ggp/base/util/gdl/transforms/GdlCleaner.java
@@ -193,7 +193,8 @@ public class GdlCleaner {
 			GdlTerm term2 = cleanParentheses(distinct.getArg2());
 			return GdlPool.getDistinct(term1, term2);
 		} else if(literal instanceof GdlNot) {
-			return GdlPool.getNot(((GdlNot) literal).getBody());
+			GdlLiteral body = ((GdlNot) literal).getBody();
+			return GdlPool.getNot(cleanParentheses(body));
 		} else if(literal instanceof GdlOr) {
 			GdlOr or = (GdlOr) literal;
 			List<GdlLiteral> disjuncts = new ArrayList<GdlLiteral>();


### PR DESCRIPTION
This was causing zero-arity relations to not get converted to
propositions when the relations were inside "not" literals.
