### PR TITLE
Improve ProverStateMachine performance on many games.

### DIFF
--- a/src/org/ggp/base/util/prover/Prover.java
+++ b/src/org/ggp/base/util/prover/Prover.java
@@ -4,7 +4,7 @@ import java.util.Set;
 
 import org.ggp.base.util.gdl.grammar.GdlSentence;
 
-public abstract class Prover
+public interface Prover
 {
 	public abstract Set<GdlSentence> askAll(GdlSentence query, Set<GdlSentence> context);
 	public abstract GdlSentence askOne(GdlSentence query, Set<GdlSentence> context);


### PR DESCRIPTION
This commit improves the AimaProver in a couple of ways:

1) Variable renaming, a perf bottleneck, is done less often.
2) When a query is found to not depend on any "true" or "does"
sentences, its result is cached for the life of the AimaProver.
This can turn arithmetic, for example, from a complex recursive
query to a fast cache lookup for most of the game.

Testing on all games in the ggp.org repositories indicates that
perf has not meaningfully worsened on any games, whereas for some
math-intensive games (e.g. Nim and Colonel Blotto variants) perf
has increased by a factor of 10 or more.

The only downside here is increased code complexity within the
AimaProver.
