### PR TITLE
HTTP uses CR+LF to separate lines

### DIFF
--- a/src/org/ggp/base/util/http/HttpWriter.java
+++ b/src/org/ggp/base/util/http/HttpWriter.java
@@ -11,13 +11,13 @@ public final class HttpWriter
     {
         PrintWriter pw = new PrintWriter(socket.getOutputStream());
 
-        pw.println("GET /" + URLEncoder.encode(data, "UTF-8") + " HTTP/1.0");
-        pw.println("Accept: text/delim");
-        pw.println("Host: " + hostField);
-        pw.println("Sender: GAMESERVER");
-        pw.println("Receiver: "+playerName);
-        pw.println();
-        pw.println();
+        pw.print("GET /" + URLEncoder.encode(data, "UTF-8") + " HTTP/1.0\r\n");
+        pw.print("Accept: text/delim\r\n");
+        pw.print("Host: " + hostField + "\r\n");
+        pw.print("Sender: GAMESERVER\r\n");
+        pw.print("Receiver: "+playerName+"\r\n");
+        pw.print("\r\n");
+        pw.print("\r\n");
 
         pw.flush();
     }
@@ -26,14 +26,14 @@ public final class HttpWriter
 	{
 		PrintWriter pw = new PrintWriter(socket.getOutputStream());
 
-		pw.println("POST / HTTP/1.0");
-		pw.println("Accept: text/delim");
-		pw.println("Host: " + hostField);
-		pw.println("Sender: GAMESERVER");
-		pw.println("Receiver: "+playerName);
-		pw.println("Content-Type: text/acl");
-		pw.println("Content-Length: " + data.length());
-		pw.println();
+		pw.print("POST / HTTP/1.0\r\n");
+		pw.print("Accept: text/delim\r\n");
+		pw.print("Host: " + hostField + "\r\n");
+		pw.print("Sender: GAMESERVER\r\n");
+		pw.print("Receiver: "+playerName + "\r\n");
+		pw.print("Content-Type: text/acl\r\n");
+		pw.print("Content-Length: " + data.length() + "\r\n");
+		pw.print("\r\n");
 		pw.print(data);
 
 		pw.flush();
@@ -43,14 +43,14 @@ public final class HttpWriter
 	{
 		PrintWriter pw = new PrintWriter(socket.getOutputStream());
 
-		pw.println("HTTP/1.0 200 OK");
-		pw.println("Content-type: text/acl");
-		pw.println("Content-length: " + data.length());
-		pw.println("Access-Control-Allow-Origin: *");
-		pw.println("Access-Control-Allow-Methods: POST, GET, OPTIONS");
-		pw.println("Access-Control-Allow-Headers: Content-Type");
-		pw.println("Access-Control-Allow-Age: 86400");
-		pw.println();
+		pw.print("HTTP/1.0 200 OK\r\n");
+		pw.print("Content-type: text/acl\r\n");
+		pw.print("Content-length: " + data.length() + "\r\n");
+		pw.print("Access-Control-Allow-Origin: *\r\n");
+		pw.print("Access-Control-Allow-Methods: POST, GET, OPTIONS\r\n");
+		pw.print("Access-Control-Allow-Headers: Content-Type\r\n");
+		pw.print("Access-Control-Allow-Age: 86400\r\n");
+		pw.print("\r\n");
 		pw.print(data);
 
 		pw.flush();


### PR DESCRIPTION
When HttpWriter sends an HTTP message, it uses the system's default line separator to separate lines.  On Unix systems, this is typically an LF character.

However, the HTTP protocol mandates that lines are separated by CR+LF - see [RFC 2616, section 4.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html).  Some HTTP servers accept messages that use just LF, whereas some don't (and, given the RFC, there is no requirement for them to be).  My player runs on Heroku, which doesn't accept these malformed messages.  This means that none of the GGP projects can connect to it (including Gamemanager, Tiltyard, and the GUI applications in ggp-base).

The fix is simply to build all HTTP messages with CR+LF separators.  This fixes my player, and Test_Http still runs correctly.
