### PR TITLE
Handle messages without a Content-Length header.

### DIFF
--- a/src/org/ggp/base/util/http/HttpReader.java
+++ b/src/org/ggp/base/util/http/HttpReader.java
@@ -88,10 +88,16 @@ public final class HttpReader
                   for (int i = 0; i < theContentLength; i++) {
                       theContent.append((char)br.read());
                   }
-                  return theContent.toString().trim();
               } else {
-                  throw new IOException("Could not find Content-Length header.");
+                  // If there is no content-length header, read from the stream until
+                  // it is closed.
+                  String t;
+                  while ((t = br.readLine()) != null) {
+                      theContent.append(t);
+                  }
               }
+
+              return theContent.toString().trim();
             }
         }
         throw new IOException("Could not find content in POST request.");


### PR DESCRIPTION
If no Content-Length is supplied on a response, the client should read from the server until the connection is closed.  See [section 4.4 of RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4).

I've included tests.
