### PR TITLE
Make sure new cache in AimaProver is thread-safe.

### DIFF
--- a/src/org/ggp/base/util/prover/aima/AimaProver.java
+++ b/src/org/ggp/base/util/prover/aima/AimaProver.java
@@ -32,7 +32,7 @@ public final class AimaProver implements Prover
 
 	private final KnowledgeBase knowledgeBase;
 
-	private final ProverCache fixedAnswerCache = new ProverCache();
+	private final ProverCache fixedAnswerCache = ProverCache.createMultiThreadedCache();
 
 	public AimaProver(List<Gdl> description)
 	{
@@ -47,7 +47,8 @@ public final class AimaProver implements Prover
 
 		Set<Substitution> answers = new HashSet<Substitution>();
 		Set<GdlSentence> alreadyAsking = new HashSet<GdlSentence>();
-		ask(goals, new KnowledgeBase(context), new Substitution(), new ProverCache(), new VariableRenamer(), askOne, answers, alreadyAsking);
+		ask(goals, new KnowledgeBase(context), new Substitution(), ProverCache.createSingleThreadedCache(),
+				new VariableRenamer(), askOne, answers, alreadyAsking);
 
 		Set<GdlSentence> results = new HashSet<GdlSentence>();
 		for (Substitution theta : answers)

--- a/src/org/ggp/base/util/prover/aima/cache/ProverCache.java
+++ b/src/org/ggp/base/util/prover/aima/cache/ProverCache.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.ggp.base.util.gdl.grammar.GdlSentence;
 import org.ggp.base.util.prover.aima.substituter.Substituter;
@@ -18,9 +19,16 @@ public final class ProverCache
 
 	private final Map<GdlSentence, Set<GdlSentence>> contents;
 
-	public ProverCache()
-	{
-		contents = new HashMap<GdlSentence, Set<GdlSentence>>();
+	private ProverCache(Map<GdlSentence, Set<GdlSentence>> mapForContents) {
+		this.contents = mapForContents;
+	}
+
+	public static ProverCache createSingleThreadedCache() {
+		return new ProverCache(new HashMap<GdlSentence, Set<GdlSentence>>());
+	}
+
+	public static ProverCache createMultiThreadedCache() {
+		return new ProverCache(new ConcurrentHashMap<GdlSentence, Set<GdlSentence>>());
 	}
 
 	/**


### PR DESCRIPTION
Previously, ProverCaches only had to exist on a single thread over the
lifetime of one call to the AimaProver. Now we need to ensure that the
longer-lived cache for constant values is thread-safe when accessed and
modified by multiple threads.

A ConcurrentHashMap provides thread-safety with relatively little
overhead. Note that computations for the same query on different threads
will return the same result, so we don't need to worry about dealing
with that.
