### PR TITLE
Use immutable data structures in a few appropriate places.

### DIFF
--- a/src/org/ggp/base/util/gdl/grammar/GdlFunction.java
+++ b/src/org/ggp/base/util/gdl/grammar/GdlFunction.java
@@ -2,15 +2,17 @@ package org.ggp.base.util.gdl.grammar;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 @SuppressWarnings("serial")
 public final class GdlFunction extends GdlTerm
 {
 
-	private final List<GdlTerm> body;
+	private final ImmutableList<GdlTerm> body;
 	private transient Boolean ground;
 	private final GdlConstant name;
 
-	GdlFunction(GdlConstant name, List<GdlTerm> body)
+	GdlFunction(GdlConstant name, ImmutableList<GdlTerm> body)
 	{
 		this.name = name;
 		this.body = body;

--- a/src/org/ggp/base/util/gdl/grammar/GdlOr.java
+++ b/src/org/ggp/base/util/gdl/grammar/GdlOr.java
@@ -2,14 +2,16 @@ package org.ggp.base.util.gdl.grammar;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 @SuppressWarnings("serial")
 public final class GdlOr extends GdlLiteral
 {
 
-	private final List<GdlLiteral> disjuncts;
+	private final ImmutableList<GdlLiteral> disjuncts;
 	private transient Boolean ground;
 
-	GdlOr(List<GdlLiteral> disjuncts)
+	GdlOr(ImmutableList<GdlLiteral> disjuncts)
 	{
 		this.disjuncts = disjuncts;
 		ground = null;
@@ -36,6 +38,10 @@ public final class GdlOr extends GdlLiteral
 	public GdlLiteral get(int index)
 	{
 		return disjuncts.get(index);
+	}
+
+	public List<GdlLiteral> getDisjuncts() {
+		return disjuncts;
 	}
 
 	@Override

--- a/src/org/ggp/base/util/gdl/grammar/GdlPool.java
+++ b/src/org/ggp/base/util/gdl/grammar/GdlPool.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
 
@@ -205,8 +206,8 @@ public final class GdlPool
 
 		GdlFunction ret = bucket.get(body);
 		if(ret == null) {
-		    body = getImmutableCopy(body);
-			ret = addToPool(body, new GdlFunction(name, body), bucket);
+		    ImmutableList<GdlTerm> immutableBody = ImmutableList.copyOf(body);
+			ret = addToPool(immutableBody, new GdlFunction(name, immutableBody), bucket);
 		}
 
 		return ret;
@@ -230,8 +231,8 @@ public final class GdlPool
 	{
 		GdlOr ret = orPool.get(disjuncts);
 		if(ret == null) {
-		    disjuncts = getImmutableCopy(disjuncts);
-			ret = addToPool(disjuncts, new GdlOr(disjuncts), orPool);
+		    ImmutableList<GdlLiteral> immutableDisjuncts = ImmutableList.copyOf(disjuncts);
+			ret = addToPool(immutableDisjuncts, new GdlOr(immutableDisjuncts), orPool);
 		}
 
 		return ret;
@@ -267,8 +268,8 @@ public final class GdlPool
 
 		GdlRelation ret = bucket.get(body);
 		if(ret == null) {
-		    body = getImmutableCopy(body);
-			ret = addToPool(body, new GdlRelation(name, body), bucket);
+		    ImmutableList<GdlTerm> immutableBody = ImmutableList.copyOf(body);
+			ret = addToPool(immutableBody, new GdlRelation(name, immutableBody), bucket);
 		}
 
 		return ret;
@@ -293,15 +294,11 @@ public final class GdlPool
 
 		GdlRule ret = bucket.get(body);
 		if(ret == null) {
-		    body = getImmutableCopy(body);
-			ret = addToPool(body, new GdlRule(head, body), bucket);
+		    ImmutableList<GdlLiteral> immutableBody = ImmutableList.copyOf(body);
+			ret = addToPool(immutableBody, new GdlRule(head, immutableBody), bucket);
 		}
 
 		return ret;
-	}
-
-	private static <T> List<T> getImmutableCopy(List<T> list) {
-	    return Collections.unmodifiableList(new ArrayList<T>(list));
 	}
 
 	/**

--- a/src/org/ggp/base/util/gdl/grammar/GdlRelation.java
+++ b/src/org/ggp/base/util/gdl/grammar/GdlRelation.java
@@ -2,15 +2,17 @@ package org.ggp.base.util.gdl.grammar;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 @SuppressWarnings("serial")
 public final class GdlRelation extends GdlSentence
 {
 
-	private final List<GdlTerm> body;
+	private final ImmutableList<GdlTerm> body;
 	private transient Boolean ground;
 	private final GdlConstant name;
 
-	GdlRelation(GdlConstant name, List<GdlTerm> body)
+	GdlRelation(GdlConstant name, ImmutableList<GdlTerm> body)
 	{
 		this.name = name;
 		this.body = body;

--- a/src/org/ggp/base/util/gdl/grammar/GdlRule.java
+++ b/src/org/ggp/base/util/gdl/grammar/GdlRule.java
@@ -2,15 +2,17 @@ package org.ggp.base.util.gdl.grammar;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 @SuppressWarnings("serial")
 public final class GdlRule extends Gdl
 {
 
-	private final List<GdlLiteral> body;
+	private final ImmutableList<GdlLiteral> body;
 	private transient Boolean ground;
 	private final GdlSentence head;
 
-	GdlRule(GdlSentence head, List<GdlLiteral> body)
+	GdlRule(GdlSentence head, ImmutableList<GdlLiteral> body)
 	{
 		this.head = head;
 		this.body = body;

--- a/src/org/ggp/base/util/gdl/transforms/ConstantCheckerFactory.java
+++ b/src/org/ggp/base/util/gdl/transforms/ConstantCheckerFactory.java
@@ -32,7 +32,7 @@ public class ConstantCheckerFactory {
 	 *
 	 * The implementation uses a forward-chaining reasoner.
 	 *
-	 * For accurate results, the rules used should have had the {@link NewVariableConstrainer}
+	 * For accurate results, the rules used should have had the {@link VariableConstrainer}
 	 * transformation applied to them.
 	 *
 	 * On average, this approach is more efficient than {@link #createWithProver(SentenceFormModel)}.

--- a/src/org/ggp/base/util/gdl/transforms/GdlCleaner.java
+++ b/src/org/ggp/base/util/gdl/transforms/GdlCleaner.java
@@ -69,6 +69,8 @@ public class GdlCleaner {
 		}
 		//TODO: Get rid of GdlPropositions in the description
 
+		//TODO: Get rid of (not (or ...))
+
 		//Get rid of (not (distinct _ _)) literals in rules
 		//TODO: Expand to functions
 		description = newDescription;

--- a/src/org/ggp/base/util/statemachine/StateMachine.java
+++ b/src/org/ggp/base/util/statemachine/StateMachine.java
@@ -16,6 +16,8 @@ import org.ggp.base.util.statemachine.exceptions.GoalDefinitionException;
 import org.ggp.base.util.statemachine.exceptions.MoveDefinitionException;
 import org.ggp.base.util.statemachine.exceptions.TransitionDefinitionException;
 
+import com.google.common.collect.ImmutableMap;
+
 
 /**
  * Provides the base class for all state machine implementations.
@@ -253,12 +255,13 @@ public abstract class StateMachine
      */
     public Map<Role, Integer> getRoleIndices()
     {
-        if(roleIndices == null) {
-            roleIndices = new HashMap<Role, Integer>();
+        if (roleIndices == null) {
+        	ImmutableMap.Builder<Role, Integer> roleIndicesBuilder = ImmutableMap.builder();
             List<Role> roles = getRoles();
             for (int i = 0; i < roles.size(); i++) {
-                roleIndices.put(roles.get(i), i);
+                roleIndicesBuilder.put(roles.get(i), i);
             }
+            roleIndices = roleIndicesBuilder.build();
         }
 
         return roleIndices;

--- a/src/org/ggp/base/util/statemachine/cache/CachedStateMachine.java
+++ b/src/org/ggp/base/util/statemachine/cache/CachedStateMachine.java
@@ -13,6 +13,8 @@ import org.ggp.base.util.statemachine.exceptions.GoalDefinitionException;
 import org.ggp.base.util.statemachine.exceptions.MoveDefinitionException;
 import org.ggp.base.util.statemachine.exceptions.TransitionDefinitionException;
 
+import com.google.common.collect.ImmutableList;
+
 public final class CachedStateMachine extends StateMachine
 {
 	private final StateMachine backingStateMachine;
@@ -73,7 +75,7 @@ public final class CachedStateMachine extends StateMachine
 		{
 			if (!entry.moves.containsKey(role))
 			{
-				entry.moves.put(role, backingStateMachine.getLegalMoves(state, role));
+				entry.moves.put(role, ImmutableList.copyOf(backingStateMachine.getLegalMoves(state, role)));
 			}
 
 			return entry.moves.get(role);

--- a/src/org/ggp/base/util/statemachine/implementation/prover/ProverStateMachine.java
+++ b/src/org/ggp/base/util/statemachine/implementation/prover/ProverStateMachine.java
@@ -21,12 +21,14 @@ import org.ggp.base.util.statemachine.exceptions.TransitionDefinitionException;
 import org.ggp.base.util.statemachine.implementation.prover.query.ProverQueryBuilder;
 import org.ggp.base.util.statemachine.implementation.prover.result.ProverResultParser;
 
+import com.google.common.collect.ImmutableList;
+
 
 public class ProverStateMachine extends StateMachine
 {
 	private MachineState initialState;
 	private Prover prover;
-	private List<Role> roles;
+	private ImmutableList<Role> roles;
 
 	/**
 	 * Initialize must be called before using the StateMachine
@@ -40,7 +42,7 @@ public class ProverStateMachine extends StateMachine
 	public void initialize(List<Gdl> description)
 	{
 		prover = new AimaProver(description);
-		roles = Role.computeRoles(description);
+		roles = ImmutableList.copyOf(Role.computeRoles(description));
 		initialState = computeInitialState();
 	}
 


### PR DESCRIPTION
Some of these are to prevent inappropriate mutations of internal data structures of e.g. state machines when they are accessed.
