### PR TITLE
Fix arbitrary recursion handling in the ProverStateMachine.

### DIFF
--- a/games/test/test_case_5d.kif
+++ b/games/test/test_case_5d.kif
@@ -1,0 +1,25 @@
+;; This tests an edge case when handling GDL.
+;; This test case ensures that a player can handle complex
+;; (yet legal) recursion. This is a regression test for the
+;; ProverStateMachine.
+
+(role you)
+(<= (r ?x ?y)
+       (s ?x ?y))
+(<= (s ?x ?y)
+      (r ?y ?x))
+
+(r 1 2)
+
+(<= (init (rTrue ?x ?y)) (r ?x ?y))
+(<= (init (sTrue ?x ?y)) (s ?x ?y))
+
+(<= (legal you proceed) (true (sTrue 1 2)))
+
+(<= (next (state 1))
+    (does you proceed))
+
+(<= terminal
+    (true (state 1)))
+
+(<= (goal you 100))

--- a/src/main/java/org/ggp/base/util/gdl/GdlUtils.java
+++ b/src/main/java/org/ggp/base/util/gdl/GdlUtils.java
@@ -40,6 +40,17 @@ public class GdlUtils {
 		return variablesList;
 	}
 
+	public static Set<GdlVariable> getVariablesSet(Gdl gdl) {
+		final Set<GdlVariable> variables = new HashSet<GdlVariable>();
+		GdlVisitors.visitAll(gdl, new GdlVisitor() {
+			@Override
+			public void visitVariable(GdlVariable variable) {
+				variables.add(variable);
+			}
+		});
+		return variables;
+	}
+
 	public static List<String> getVariableNames(Gdl gdl) {
 		List<GdlVariable> variables = getVariables(gdl);
 		List<String> variableNames = new ArrayList<String>();

--- a/src/test/java/org/ggp/base/util/statemachine/implementation/prover/ProverStateMachineTest.java
+++ b/src/test/java/org/ggp/base/util/statemachine/implementation/prover/ProverStateMachineTest.java
@@ -155,6 +155,35 @@ public class ProverStateMachineTest extends Assert {
         assertEquals(Collections.singletonList(100), sm.getGoals(state));
     }
 
+    @Test
+    public void testCase5D() throws Exception {
+        List<Gdl> desc = new TestGameRepository().getGame("test_case_5d").getRules();
+        sm.initialize(desc);
+        MachineState state = sm.getInitialState();
+        Role you = new Role(GdlPool.getConstant("you"));
+        assertFalse(sm.isTerminal(state));
+        assertEquals(1, sm.getLegalMoves(state, you).size());
+        assertEquals(move("proceed"), sm.getLegalMoves(state, you).get(0));
+        state = sm.getNextState(state, Collections.singletonList(move("proceed")));
+        assertTrue(sm.isTerminal(state));
+        assertEquals(100, sm.getGoal(state, you));
+        assertEquals(Collections.singletonList(100), sm.getGoals(state));
+    }
+
+    @Test
+    public void testDistinctAtBeginningOfRule() throws Exception {
+        List<Gdl> desc = new TestGameRepository().getGame("test_distinct_beginning_rule").getRules();
+        sm.initialize(desc);
+        MachineState state = sm.getInitialState();
+        Role you = new Role(GdlPool.getConstant("you"));
+        assertFalse(sm.isTerminal(state));
+        assertEquals(2, sm.getLegalMoves(state, you).size());
+        state = sm.getNextState(state, Collections.singletonList(move("do a b")));
+        assertTrue(sm.isTerminal(state));
+        assertEquals(100, sm.getGoal(state, you));
+        assertEquals(Collections.singletonList(100), sm.getGoals(state));
+    }
+
     protected Move move(String description) {
         String[] parts = description.split(" ");
         GdlConstant head = GdlPool.getConstant(parts[0]);


### PR DESCRIPTION
The old approach was a hack that worked for one particular game I was
writing, but did not give correct results in other cases. (The approach
before that resulted in StackOverflowErrors.) The new approach should
give correct results in all cases.

It does not appear there are any performance regressions for existing
games.