### PR TITLE
Fix OPNF propnet generation for test case 5b.

### DIFF
--- a/src/main/java/org/ggp/base/util/propnet/factory/OptimizingPropNetFactory.java
+++ b/src/main/java/org/ggp/base/util/propnet/factory/OptimizingPropNetFactory.java
@@ -184,7 +184,9 @@ public class OptimizingPropNetFactory {
 				//Only add it if it's important
 				if(form.getName().equals(LEGAL)
 						|| form.getName().equals(GOAL)
-						|| form.getName().equals(INIT)) {
+						|| form.getName().equals(INIT)
+						|| form.getName().equals(NEXT)
+						|| form.getName().equals(TERMINAL)) {
 					//Add it
 					for (GdlSentence trueSentence : constantChecker.getTrueSentences(form)) {
 						Proposition trueProp = new Proposition(trueSentence);


### PR DESCRIPTION
We weren't keeping the proposition for (next done) in the propnet
despite it being important and always true. This is unusual GDL, but
legal, so we should handle it.