### PR TITLE
bugfix: catch calls same method as try in GdlFactory.

### DIFF
--- a/src/main/java/org/ggp/base/util/gdl/factory/GdlFactory.java
+++ b/src/main/java/org/ggp/base/util/gdl/factory/GdlFactory.java
@@ -41,7 +41,6 @@ public final class GdlFactory
         }
         catch (Exception e)
         {
-            createGdl(symbol);
             throw new GdlFormatException(symbol);
         }
     }


### PR DESCRIPTION
In GdlFactory.create(Symbol), there is a try/catch, where the try calls
GdlFactory.createGdl(Symbol), the catch is of any Exception... but the
catch re-calls createGdl() before trying to throw a more meaningful
GdlFormatException.  Throwing the GdlFormatException can never happen,
but should.