### PR TITLE
Correct names in Clojure documentation

### DIFF
--- a/src/main/java/org/ggp/base/player/gamer/clojure/ClojureGamer.java
+++ b/src/main/java/org/ggp/base/player/gamer/clojure/ClojureGamer.java
@@ -21,12 +21,12 @@ import clojure.lang.Var;
  *    getClojureGamerName() to indicate where the Clojure source code file is.
  *    This is the Java stub that refers to the real Clojure gamer class.
  *
- * 2) Create the Clojure source code file, in the /src_clj/ directory in the root
- *    directory for this project. Make sure that the stub points to this class,
- *    and that the Clojure class is a valid subclass of Gamer.
+ * 2) Create the Clojure source code file, in the /src/main/resources/ directory
+ *    in the root directory for this project. Make sure that the stub points to 
+ *    this class, and that the Clojure class is a valid subclass of Gamer.
  *
- * For examples where this has already been done, see @ClojureLegalGamerStub,
- * which is implemented in Clojure and hook into the Java framework using the
+ * For examples where this has already been done, see @SampleClojureGamerStub,
+ * which is implemented in Clojure and hooked into the Java framework using the
  * ClojureGamer stub.
  *
  * @author Sam Schreiber

--- a/src/main/java/org/ggp/base/player/gamer/clojure/stubs/SampleClojureGamerStub.java
+++ b/src/main/java/org/ggp/base/player/gamer/clojure/stubs/SampleClojureGamerStub.java
@@ -2,7 +2,7 @@ package org.ggp.base.player.gamer.clojure.stubs;
 import org.ggp.base.player.gamer.clojure.ClojureGamer;
 
 /**
- * ClojureLegalGamerStub is a stub that points to a version of @RandomGamer that
+ * SampleClojureGamerStub is a stub that points to a version of @RandomGamer that
  * has been implemented in Clojure. This stub needs to exist so that the Clojure
  * code can interoperate with the rest of the Java framework (and applications
  * like Kiosk and PlayerPanel as a result).


### PR DESCRIPTION
The name of SampleClojureGamerStub has changed multiple times and some of
the in code documentation does not reflect this. The instructions on
setting up a new Clojure gamer also directed to use the src_clj folder
which should no longer be used. Instead src/main/resources should be
used.