### PR TITLE
Added some sample Scala players + SBT build for them

### DIFF
--- a/src/main/resources/scala/build.sbt
+++ b/src/main/resources/scala/build.sbt
@@ -1,0 +1,16 @@
+name := "ggp-base-scala"
+
+version := "0.1"
+
+
+
+scalaVersion := "2.11.7"
+
+
+
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test"
+
+
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
+
+externalDependencyClasspath in Compile += baseDirectory.value / "../../../../build/classes/main"

--- a/src/main/resources/scala/src/main/scala/org/ggp/base/scala/player/gamer/statemachine/SampleMonteCarloGamer.scala
+++ b/src/main/resources/scala/src/main/scala/org/ggp/base/scala/player/gamer/statemachine/SampleMonteCarloGamer.scala
@@ -1,0 +1,66 @@
+package org.ggp.base.scala.player.gamer.statemachine
+
+import org.ggp.base.player.gamer.statemachine.StateMachineGamer
+import org.ggp.base.util.game.Game
+import org.ggp.base.util.statemachine.implementation.prover.ProverStateMachine
+import org.ggp.base.util.statemachine.{Move, StateMachine}
+import scala.collection.JavaConversions
+
+/**
+ * Created by steve on 11/1/2015.
+ */
+class SampleMonteCarloGamer extends StateMachineGamer {
+  import SampleMonteCarloGamer._
+
+  def stateMachineSelectMove(l: Long): Move = {
+    val endByTime = l - SAFETY_MARGIN
+    val role = getRole
+    val sm = getStateMachine
+    val currState = getCurrentState
+    val moves = JavaConversions.asScalaIterator(sm.getLegalMoves(currState, role).iterator())
+
+    def findBestMoveFromMoves(moves: List[Move]): Move = {
+      def improveMoveEstimatesUntil(estimates: Map[Move,Double], untilCond: => Boolean)(iteration: Int = 0): Map[Move,Double] = {
+        def improveEstimate(currentEstimate: (Move, Double)): (Move, Double) =  currentEstimate match {
+          case (move, score) => {
+            val sampleScore: Double = sm.getGoal(sm.performDepthCharge(sm.getRandomNextState(currState, role, move), null), role)
+            (move, (score*iteration + sampleScore)/(iteration+1))
+          }
+        }
+
+        if ( untilCond ) {
+          //println(s"$iteration iterations performed on ${moves.length} moves")
+          estimates
+        }
+        else {
+          val newEstimates = estimates map improveEstimate
+          improveMoveEstimatesUntil(newEstimates, untilCond)(iteration+1)
+        }
+      }
+
+      val initialEstimates = Map(moves map { m => (m,0.0) }: _*)
+      val finalEstimates = improveMoveEstimatesUntil(initialEstimates, System.currentTimeMillis() >= endByTime)(0)
+      //println(s"Final estimates: ${finalEstimates.toString}")
+
+      finalEstimates.maxBy(_._2)._1
+    }
+
+    findBestMoveFromMoves(moves.toList)
+  }
+
+  def stateMachineAbort(): Unit = {}
+
+  def stateMachineMetaGame(l: Long): Unit = {}
+
+  def stateMachineStop(): Unit = {}
+
+  def getInitialStateMachine: StateMachine = new ProverStateMachine()
+
+  def getName: String = "Sample Scala MonteCarlo gamer"
+
+  def preview(game: Game, l: Long): Unit = {}}
+
+object SampleMonteCarloGamer
+{
+  val SAFETY_MARGIN = 1000
+}

--- a/src/main/resources/scala/src/main/scala/org/ggp/base/scala/player/gamer/statemachine/SampleRandomGamer.scala
+++ b/src/main/resources/scala/src/main/scala/org/ggp/base/scala/player/gamer/statemachine/SampleRandomGamer.scala
@@ -1,0 +1,31 @@
+package org.ggp.base.scala.player.gamer.statemachine
+
+import org.ggp.base.player.gamer.statemachine.StateMachineGamer
+import org.ggp.base.util.game.Game
+import org.ggp.base.util.statemachine.implementation.prover.ProverStateMachine
+import org.ggp.base.util.statemachine.{Move, StateMachine}
+
+/**
+ * Created by steve on 11/1/2015.
+ */
+class SampleRandomGamer extends StateMachineGamer {
+  def stateMachineSelectMove(l: Long): Move = {
+    val sm = getStateMachine
+    val state = getCurrentState
+    val role = getRole
+
+    sm.getRandomMove(state, role)
+  }
+
+  def stateMachineAbort(): Unit = {}
+
+  def stateMachineMetaGame(l: Long): Unit = {}
+
+  def stateMachineStop(): Unit = {}
+
+  def getInitialStateMachine: StateMachine = new ProverStateMachine()
+
+  def getName: String = "Sample Scala legal gamer"
+
+  def preview(game: Game, l: Long): Unit = {}
+}


### PR DESCRIPTION
Sample players written in Scala (Random and MonteCarlo).  The build is SBT and assumes the main ggp-base java has already been built (in order to add the necessary class dependency).  Accordingly the .SBT file is sensitive to the relative placement of the scala code in the overall hierarchy - I have positioned it as a sibling of the Clojure and Python players.

To use build with SBT and add the resulting class files to your classpath when running Player (which will then pick up the new players by reflection)