### PR TITLE
Make the pre-scheduling player status check case insensitive

### DIFF
--- a/src/main/java/org/ggp/base/apps/server/scheduling/Scheduler.java
+++ b/src/main/java/org/ggp/base/apps/server/scheduling/Scheduler.java
@@ -65,7 +65,7 @@ public final class Scheduler implements Observer
 
     private synchronized boolean canSchedule(PendingMatch spec) {
         for (PlayerPresence player : spec.thePlayers) {
-            if (!player.getStatus().equals("available")) {
+            if (!player.getStatus().toLowerCase().equals("available")) {
                 return false;
             }
             if (activePlayers.contains(player.getName())) {


### PR DESCRIPTION
When the game server displays the status color bubble thing in the UI it uses `.toLowerCase()` to allow for uppercase statuses.  But when it checks whether it can actually schedule a requested match, it compares the raw status string against a lowercase version, and so it'll just hang forever on "pending" and never schedule the match with players that report their status in uppercase.
