### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/ggp/base/apps/benchmark/EndgameCaseGenerator.java
+++ b/src/main/java/org/ggp/base/apps/benchmark/EndgameCaseGenerator.java
@@ -35,6 +35,9 @@ import org.ggp.base.util.statemachine.implementation.prover.ProverStateMachine;
  * @author Sam Schreiber
  */
 public class EndgameCaseGenerator {
+    private EndgameCaseGenerator() {
+    }
+
     public static void main(String[] args) throws MoveDefinitionException, TransitionDefinitionException, GoalDefinitionException {
         generateTestCase("connectFour", 0, 5, 6, new ProverStateMachine());
     }

--- a/src/main/java/org/ggp/base/apps/research/MatchArchiveProcessor.java
+++ b/src/main/java/org/ggp/base/apps/research/MatchArchiveProcessor.java
@@ -32,6 +32,9 @@ public final class MatchArchiveProcessor
     // Set this to the path of the downloaded match archive file.
     public static final File ARCHIVE_FILE = new File(new File(new File(new File(System.getProperty("user.home")), "matchArchive"), "data"), "allMatches");
 
+    private MatchArchiveProcessor() {
+    }
+
     public static void main(String[] args) throws IOException, JSONException
     {
         AggregateData data = new AggregateData();

--- a/src/main/java/org/ggp/base/apps/utilities/GameServerRunner.java
+++ b/src/main/java/org/ggp/base/apps/utilities/GameServerRunner.java
@@ -33,6 +33,9 @@ import org.ggp.base.util.symbol.factory.exceptions.SymbolFormatException;
  */
 public final class GameServerRunner
 {
+    private GameServerRunner() {
+    }
+
     public static void main(String[] args) throws IOException, SymbolFormatException, GdlFormatException, InterruptedException, GoalDefinitionException
     {
         // Extract the desired configuration from the command line.

--- a/src/main/java/org/ggp/base/server/request/RequestBuilder.java
+++ b/src/main/java/org/ggp/base/server/request/RequestBuilder.java
@@ -10,6 +10,9 @@ import org.ggp.base.util.statemachine.Role;
 
 public final class RequestBuilder
 {
+    private RequestBuilder() {
+    }
+
     public static String getPlayRequest(String matchId, List<Move> moves, GdlScrambler scrambler)
     {
         if (moves == null) {

--- a/src/main/java/org/ggp/base/util/concurrency/ConcurrencyUtils.java
+++ b/src/main/java/org/ggp/base/util/concurrency/ConcurrencyUtils.java
@@ -1,6 +1,9 @@
 package org.ggp.base.util.concurrency;
 
 public class ConcurrencyUtils {
+    private ConcurrencyUtils() {
+    }
+
     /**
      * If the thread has been interrupted, throws an InterruptedException.
      */

--- a/src/main/java/org/ggp/base/util/crypto/BaseCryptography.java
+++ b/src/main/java/org/ggp/base/util/crypto/BaseCryptography.java
@@ -19,6 +19,9 @@ import external.JSON.JSONException;
 import external.JSON.JSONObject;
 
 public class BaseCryptography {
+    private BaseCryptography() {
+    }
+
     public static void main(String args[]) {
         EncodedKeyPair k = generateKeys();
         System.out.println("{\"PK\":\"" + k.thePublicKey + "\", \"SK\":\"" + k.thePrivateKey + "\"}");

--- a/src/main/java/org/ggp/base/util/files/FileUtils.java
+++ b/src/main/java/org/ggp/base/util/files/FileUtils.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 import java.io.PrintStream;
 
 public class FileUtils {
+    private FileUtils() {
+    }
+
     public static String readFileAsString(File file) {
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             StringBuilder fileData = new StringBuilder(10000);

--- a/src/main/java/org/ggp/base/util/game/LocalGameRepository.java
+++ b/src/main/java/org/ggp/base/util/game/LocalGameRepository.java
@@ -94,6 +94,9 @@ public final class LocalGameRepository extends GameRepository {
     static class BaseRepository {
         public static final String repositoryRootDirectory = theLocalRepoURL;
 
+        private BaseRepository() {
+        }
+
         public static boolean shouldIgnoreFile(String fileName) {
             if (fileName.startsWith(".")) return true;
             if (fileName.contains(" ")) return true;
@@ -309,6 +312,9 @@ public final class LocalGameRepository extends GameRepository {
     }
 
     static class MetadataCompleter {
+        private MetadataCompleter() {
+        }
+
         /**
          * Complete fields in the metadata procedurally, based on the game rulesheet.
          * This is used to fill in the number of roles, and create a list containing

--- a/src/main/java/org/ggp/base/util/gdl/GdlUtils.java
+++ b/src/main/java/org/ggp/base/util/gdl/GdlUtils.java
@@ -24,6 +24,9 @@ import org.ggp.base.util.gdl.grammar.GdlVariable;
 
 
 public class GdlUtils {
+    private GdlUtils() {
+    }
+
     //TODO (AL): Check if we can switch over to just having this return a set.
     public static List<GdlVariable> getVariables(Gdl gdl) {
         final List<GdlVariable> variablesList = new ArrayList<GdlVariable>();

--- a/src/main/java/org/ggp/base/util/gdl/model/SentenceDomainModelFactory.java
+++ b/src/main/java/org/ggp/base/util/gdl/model/SentenceDomainModelFactory.java
@@ -6,6 +6,9 @@ import java.util.Map;
 import org.ggp.base.util.gdl.grammar.Gdl;
 
 public class SentenceDomainModelFactory {
+    private SentenceDomainModelFactory() {
+    }
+
     public static ImmutableSentenceDomainModel createWithCartesianDomains(List<Gdl> description) throws InterruptedException {
         ImmutableSentenceFormModel formModel = SentenceFormModelFactory.create(description);
 

--- a/src/main/java/org/ggp/base/util/gdl/model/SentenceDomainModelOptimizer.java
+++ b/src/main/java/org/ggp/base/util/gdl/model/SentenceDomainModelOptimizer.java
@@ -35,6 +35,9 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 
 public class SentenceDomainModelOptimizer {
+    private SentenceDomainModelOptimizer() {
+    }
+
     /**
      * Given a SentenceDomainModel, returns an ImmutableSentenceDomainModel
      * with Cartesian domains that tries to minimize the domains of sentence

--- a/src/main/java/org/ggp/base/util/gdl/model/SentenceFormModelFactory.java
+++ b/src/main/java/org/ggp/base/util/gdl/model/SentenceFormModelFactory.java
@@ -24,6 +24,9 @@ import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 
 public class SentenceFormModelFactory {
+    private SentenceFormModelFactory() {
+    }
+
     /**
      * Creates a SentenceFormModel for the given game description.
      *

--- a/src/main/java/org/ggp/base/util/gdl/model/SentenceModelUtils.java
+++ b/src/main/java/org/ggp/base/util/gdl/model/SentenceModelUtils.java
@@ -6,8 +6,11 @@ import org.ggp.base.util.gdl.grammar.GdlSentence;
 
 
 public class SentenceModelUtils {
+    private SentenceModelUtils() {
+    }
+
     public static boolean inSentenceFormGroup(GdlSentence sentence,
-            Set<SentenceForm> forms) {
+                                              Set<SentenceForm> forms) {
         for(SentenceForm form : forms)
             if(form.matches(sentence))
                 return true;

--- a/src/main/java/org/ggp/base/util/gdl/model/assignments/AssignmentsFactory.java
+++ b/src/main/java/org/ggp/base/util/gdl/model/assignments/AssignmentsFactory.java
@@ -20,9 +20,12 @@ import org.ggp.base.util.gdl.model.SentenceForm;
 
 public class AssignmentsFactory {
 
+    private AssignmentsFactory() {
+    }
+
     public static Assignments getAssignmentsForRule(GdlRule rule,
-            SentenceDomainModel model, Map<SentenceForm, FunctionInfo> functionInfoMap,
-            Map<SentenceForm, ? extends Collection<GdlSentence>> completedSentenceFormValues) {
+                                                    SentenceDomainModel model, Map<SentenceForm, FunctionInfo> functionInfoMap,
+                                                    Map<SentenceForm, ? extends Collection<GdlSentence>> completedSentenceFormValues) {
         return new AssignmentsImpl(rule,
                 SentenceDomainModels.getVarDomains(rule, model, VarDomainOpts.INCLUDE_HEAD),
                 functionInfoMap,

--- a/src/main/java/org/ggp/base/util/gdl/transforms/CondensationIsolator.java
+++ b/src/main/java/org/ggp/base/util/gdl/transforms/CondensationIsolator.java
@@ -79,6 +79,9 @@ import com.google.common.collect.Sets;
  *
  */
 public class CondensationIsolator {
+    private CondensationIsolator() {
+    }
+
     public static List<Gdl> run(List<Gdl> description) throws InterruptedException {
         //This class is not put together in any "optimal" way, so it's left in
         //an unpolished state for now. A better version would use estimates of

--- a/src/main/java/org/ggp/base/util/gdl/transforms/GdlCleaner.java
+++ b/src/main/java/org/ggp/base/util/gdl/transforms/GdlCleaner.java
@@ -24,6 +24,9 @@ public class GdlCleaner {
     private final static int MAX_ITERATIONS = 100;
     private final static GdlConstant BASE = GdlPool.getConstant("base");
 
+    private GdlCleaner() {
+    }
+
     public static List<Gdl> run(List<Gdl> description) {
         for (int i = 0; i < MAX_ITERATIONS; i++) {
             List<Gdl> newDescription = runOnce(description);

--- a/src/main/java/org/ggp/base/util/gdl/transforms/Relationizer.java
+++ b/src/main/java/org/ggp/base/util/gdl/transforms/Relationizer.java
@@ -23,6 +23,9 @@ import org.ggp.base.util.gdl.model.SentenceFormModelFactory;
 
 public class Relationizer {
 
+    private Relationizer() {
+    }
+
     /**
      * Searches the description for statements that are needlessly treated as
      * base propositions when they could be expressed as simple relations, and

--- a/src/main/java/org/ggp/base/util/gdl/transforms/VariableConstrainer.java
+++ b/src/main/java/org/ggp/base/util/gdl/transforms/VariableConstrainer.java
@@ -44,6 +44,9 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 
 public class VariableConstrainer {
+    private VariableConstrainer() {
+    }
+
     /**
      * Modifies a GDL description by replacing all rules in which variables could be bound to
      * functions, so that the new rules will only bind constants to variables. Also automatically

--- a/src/main/java/org/ggp/base/util/loader/RemoteResourceLoader.java
+++ b/src/main/java/org/ggp/base/util/loader/RemoteResourceLoader.java
@@ -19,6 +19,9 @@ import external.JSON.JSONObject;
  * @author Sam
  */
 public class RemoteResourceLoader {
+    private RemoteResourceLoader() {
+    }
+
     public static JSONObject loadJSON(String theURL) throws JSONException, IOException {
         return loadJSON(theURL, 1);
     }

--- a/src/main/java/org/ggp/base/util/match/MatchPublisher.java
+++ b/src/main/java/org/ggp/base/util/match/MatchPublisher.java
@@ -10,6 +10,9 @@ import java.net.URL;
 import java.net.URLEncoder;
 
 public class MatchPublisher {
+    private MatchPublisher() {
+    }
+
     public static String publishToSpectatorServer(String spectatorURL, Match theMatch) throws IOException {
         if (theMatch.getGameRepositoryURL().isEmpty()) {
             throw new IOException("Match doesn't have appropriate metadata for publication to a spectator server: " + theMatch);

--- a/src/main/java/org/ggp/base/util/propnet/factory/LegacyPropNetFactory.java
+++ b/src/main/java/org/ggp/base/util/propnet/factory/LegacyPropNetFactory.java
@@ -18,6 +18,9 @@ import org.ggp.base.util.statemachine.Role;
  */
 public final class LegacyPropNetFactory
 {
+    private LegacyPropNetFactory() {
+    }
+
     /**
      * Creates a PropNet from a game description using the following process:
      * <ol>

--- a/src/main/java/org/ggp/base/util/prover/aima/substituter/Substituter.java
+++ b/src/main/java/org/ggp/base/util/prover/aima/substituter/Substituter.java
@@ -22,6 +22,9 @@ import org.ggp.base.util.prover.aima.substitution.Substitution;
 public final class Substituter
 {
 
+    private Substituter() {
+    }
+
     public static GdlLiteral substitute(GdlLiteral literal, Substitution theta)
     {
         return substituteLiteral(literal, theta);

--- a/src/main/java/org/ggp/base/util/reflection/ProjectSearcher.java
+++ b/src/main/java/org/ggp/base/util/reflection/ProjectSearcher.java
@@ -12,6 +12,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 public class ProjectSearcher {
+    private ProjectSearcher() {
+    }
+
     public static void main(String[] args)
     {
         System.out.println(GAMERS);

--- a/src/main/java/org/ggp/base/util/statemachine/implementation/prover/query/ProverQueryBuilder.java
+++ b/src/main/java/org/ggp/base/util/statemachine/implementation/prover/query/ProverQueryBuilder.java
@@ -28,6 +28,9 @@ public final class ProverQueryBuilder
     private final static GdlProposition TERMINAL_QUERY = GdlPool.getProposition(GdlPool.getConstant("terminal"));
     private final static GdlVariable VARIABLE = GdlPool.getVariable("?x");
 
+    private ProverQueryBuilder() {
+    }
+
     public static Set<GdlSentence> getContext(MachineState state)
     {
         return state.getContents();

--- a/src/main/java/org/ggp/base/util/statemachine/verifier/StateMachineVerifier.java
+++ b/src/main/java/org/ggp/base/util/statemachine/verifier/StateMachineVerifier.java
@@ -11,6 +11,9 @@ import org.ggp.base.util.statemachine.StateMachine;
 
 
 public class StateMachineVerifier {
+    private StateMachineVerifier() {
+    }
+
     public static boolean checkMachineConsistency(StateMachine theReference, StateMachine theSubject, long timeToSpend) {
         long startTime = System.currentTimeMillis();
 

--- a/src/main/java/org/ggp/base/util/symbol/factory/SymbolFactory.java
+++ b/src/main/java/org/ggp/base/util/symbol/factory/SymbolFactory.java
@@ -13,6 +13,9 @@ import org.ggp.base.util.symbol.grammar.SymbolPool;
 
 public final class SymbolFactory
 {
+    private SymbolFactory() {
+    }
+
     public static Symbol create(String string) throws SymbolFormatException
     {
         try


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.