### PR TITLE
Modifiers should be declared in the correct order

### DIFF
--- a/src/main/java/org/ggp/base/apps/kiosk/templates/GameCanvas_Chessboard.java
+++ b/src/main/java/org/ggp/base/apps/kiosk/templates/GameCanvas_Chessboard.java
@@ -38,7 +38,7 @@ public abstract class GameCanvas_Chessboard extends GameCanvas_FancyGrid {
     }
 
     // This function only works properly when coordinates start at one.
-    public final static String coordinateToLetter(int x) {
+    public static final String coordinateToLetter(int x) {
         return "" + ((char) ('a' + x - 1));
     }
 }

--- a/src/main/java/org/ggp/base/apps/research/Aggregation.java
+++ b/src/main/java/org/ggp/base/apps/research/Aggregation.java
@@ -15,7 +15,7 @@ import java.util.TreeSet;
  */
 public abstract class Aggregation<T extends Comparable<T>>
 {
-    final private Map<String, T> entryData = new HashMap<String, T>();
+    private final Map<String, T> entryData = new HashMap<String, T>();
 
     boolean containsEntry(String key) {
         return entryData.containsKey(key);

--- a/src/main/java/org/ggp/base/util/gdl/transforms/GdlCleaner.java
+++ b/src/main/java/org/ggp/base/util/gdl/transforms/GdlCleaner.java
@@ -21,8 +21,8 @@ import org.ggp.base.util.gdl.grammar.GdlVariable;
 
 //Cleans up various issues with games to make them more standardized.
 public class GdlCleaner {
-    private final static int MAX_ITERATIONS = 100;
-    private final static GdlConstant BASE = GdlPool.getConstant("base");
+    private static final int MAX_ITERATIONS = 100;
+    private static final GdlConstant BASE = GdlPool.getConstant("base");
 
     public static List<Gdl> run(List<Gdl> description) {
         for (int i = 0; i < MAX_ITERATIONS; i++) {

--- a/src/main/java/org/ggp/base/util/gdl/transforms/VariableConstrainer.java
+++ b/src/main/java/org/ggp/base/util/gdl/transforms/VariableConstrainer.java
@@ -377,7 +377,7 @@ public class VariableConstrainer {
         return results;
     }
 
-    private static abstract class UnusedVariableGenerator {
+    private abstract static class UnusedVariableGenerator {
         public GdlFunction replaceVariablesAndConstants(GdlFunction function) {
             Map<GdlVariable, GdlVariable> assignment = Maps.newHashMap();
 

--- a/src/main/java/org/ggp/base/util/presence/PlayerPresence.java
+++ b/src/main/java/org/ggp/base/util/presence/PlayerPresence.java
@@ -6,8 +6,8 @@ import org.ggp.base.server.request.RequestBuilder;
 import org.ggp.base.util.http.HttpRequest;
 
 public class PlayerPresence {
-    final private String host;
-    final private int port;
+    private final String host;
+    private final int port;
     private String name;
     private String status;
     private long statusTime;

--- a/src/main/java/org/ggp/base/util/propnet/factory/OptimizingPropNetFactory.java
+++ b/src/main/java/org/ggp/base/util/propnet/factory/OptimizingPropNetFactory.java
@@ -90,18 +90,18 @@ import com.google.common.collect.Multiset;
  *
  */
 public class OptimizingPropNetFactory {
-    static final private GdlConstant LEGAL = GdlPool.getConstant("legal");
-    static final private GdlConstant NEXT = GdlPool.getConstant("next");
-    static final private GdlConstant TRUE = GdlPool.getConstant("true");
-    static final private GdlConstant DOES = GdlPool.getConstant("does");
-    static final private GdlConstant GOAL = GdlPool.getConstant("goal");
-    static final private GdlConstant INIT = GdlPool.getConstant("init");
+    private static final GdlConstant LEGAL = GdlPool.getConstant("legal");
+    private static final GdlConstant NEXT = GdlPool.getConstant("next");
+    private static final GdlConstant TRUE = GdlPool.getConstant("true");
+    private static final GdlConstant DOES = GdlPool.getConstant("does");
+    private static final GdlConstant GOAL = GdlPool.getConstant("goal");
+    private static final GdlConstant INIT = GdlPool.getConstant("init");
     //TODO: This currently doesn't actually give a different constant from INIT
-    static final private GdlConstant INIT_CAPS = GdlPool.getConstant("INIT");
-    static final private GdlConstant TERMINAL = GdlPool.getConstant("terminal");
-    static final private GdlConstant BASE = GdlPool.getConstant("base");
-    static final private GdlConstant INPUT = GdlPool.getConstant("input");
-    static final private GdlProposition TEMP = GdlPool.getProposition(GdlPool.getConstant("TEMP"));
+    private static final GdlConstant INIT_CAPS = GdlPool.getConstant("INIT");
+    private static final GdlConstant TERMINAL = GdlPool.getConstant("terminal");
+    private static final GdlConstant BASE = GdlPool.getConstant("base");
+    private static final GdlConstant INPUT = GdlPool.getConstant("input");
+    private static final GdlProposition TEMP = GdlPool.getProposition(GdlPool.getConstant("TEMP"));
 
     /**
      * Creates a PropNet for the game with the given description.

--- a/src/main/java/org/ggp/base/util/statemachine/implementation/prover/query/ProverQueryBuilder.java
+++ b/src/main/java/org/ggp/base/util/statemachine/implementation/prover/query/ProverQueryBuilder.java
@@ -19,14 +19,14 @@ import org.ggp.base.util.statemachine.Role;
 public final class ProverQueryBuilder
 {
 
-    private final static GdlConstant DOES = GdlPool.getConstant("does");
-    private final static GdlConstant GOAL = GdlPool.getConstant("goal");
-    private final static GdlRelation INIT_QUERY = GdlPool.getRelation(GdlPool.getConstant("init"), new GdlTerm[] { GdlPool.getVariable("?x") });
-    private final static GdlConstant LEGAL = GdlPool.getConstant("legal");
-    private final static GdlRelation NEXT_QUERY = GdlPool.getRelation(GdlPool.getConstant("next"), new GdlTerm[] { GdlPool.getVariable("?x") });
-    private final static GdlRelation ROLE_QUERY = GdlPool.getRelation(GdlPool.getConstant("role"), new GdlTerm[] { GdlPool.getVariable("?x") });
-    private final static GdlProposition TERMINAL_QUERY = GdlPool.getProposition(GdlPool.getConstant("terminal"));
-    private final static GdlVariable VARIABLE = GdlPool.getVariable("?x");
+    private static final GdlConstant DOES = GdlPool.getConstant("does");
+    private static final GdlConstant GOAL = GdlPool.getConstant("goal");
+    private static final GdlRelation INIT_QUERY = GdlPool.getRelation(GdlPool.getConstant("init"), new GdlTerm[] { GdlPool.getVariable("?x") });
+    private static final GdlConstant LEGAL = GdlPool.getConstant("legal");
+    private static final GdlRelation NEXT_QUERY = GdlPool.getRelation(GdlPool.getConstant("next"), new GdlTerm[] { GdlPool.getVariable("?x") });
+    private static final GdlRelation ROLE_QUERY = GdlPool.getRelation(GdlPool.getConstant("role"), new GdlTerm[] { GdlPool.getVariable("?x") });
+    private static final GdlProposition TERMINAL_QUERY = GdlPool.getProposition(GdlPool.getConstant("terminal"));
+    private static final GdlVariable VARIABLE = GdlPool.getVariable("?x");
 
     public static Set<GdlSentence> getContext(MachineState state)
     {

--- a/src/main/java/org/ggp/base/util/statemachine/implementation/prover/result/ProverResultParser.java
+++ b/src/main/java/org/ggp/base/util/statemachine/implementation/prover/result/ProverResultParser.java
@@ -17,7 +17,7 @@ import org.ggp.base.util.statemachine.Role;
 public final class ProverResultParser
 {
 
-    private final static GdlConstant TRUE = GdlPool.getConstant("true");
+    private static final GdlConstant TRUE = GdlPool.getConstant("true");
 
     public List<Move> toMoves(Set<GdlSentence> results)
     {

--- a/src/main/java/org/ggp/base/util/symbol/grammar/SymbolPool.java
+++ b/src/main/java/org/ggp/base/util/symbol/grammar/SymbolPool.java
@@ -8,8 +8,8 @@ import java.util.concurrent.ConcurrentMap;
 public final class SymbolPool
 {
 
-    private final static ConcurrentMap<String, SymbolAtom> atomPool = new ConcurrentHashMap<String, SymbolAtom>();
-    private final static ConcurrentMap<List<Symbol>, SymbolList> listPool = new ConcurrentHashMap<List<Symbol>, SymbolList>();
+    private static final ConcurrentMap<String, SymbolAtom> atomPool = new ConcurrentHashMap<String, SymbolAtom>();
+    private static final ConcurrentMap<List<Symbol>, SymbolList> listPool = new ConcurrentHashMap<List<Symbol>, SymbolList>();
 
     /**
      * If the pool does not have a mapping for the given key, adds a mapping from key to value

--- a/src/main/java/org/ggp/base/util/ui/CloseableTabs.java
+++ b/src/main/java/org/ggp/base/util/ui/CloseableTabs.java
@@ -16,7 +16,7 @@ import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 
 public class CloseableTabs {
-    private final static int CLOSE_ICON_SIZE = 8;
+    private static final int CLOSE_ICON_SIZE = 8;
 
     public static void addClosableTab(JTabbedPane tabPane, JComponent tabContent, String tabName, AbstractAction closeAction) {
         JPanel tabTopPanel = new JPanel(new GridBagLayout());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
Please let me know if you have any questions.
Ayman Abdelghany.