### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/src/main/java/org/ggp/base/apps/kiosk/games/BlockerCanvas.java
+++ b/src/main/java/org/ggp/base/apps/kiosk/games/BlockerCanvas.java
@@ -28,8 +28,8 @@ public class BlockerCanvas extends GameCanvas_FancyGrid {
         int width = g.getClipBounds().width;
         int height = g.getClipBounds().height;
 
-        boolean isBlue = (yCell == 0) || (yCell == 5);
-        boolean isBlack = ((xCell == 0) || (xCell == 5)) && !isBlue;
+        boolean isBlue = yCell == 0 || yCell == 5;
+        boolean isBlack = (xCell == 0 || xCell == 5) && !isBlue;
 
         if(isBlue) {
             CommonGraphics.drawBubbles(g, xCell*11+yCell);

--- a/src/main/java/org/ggp/base/apps/server/states/StatesPanel.java
+++ b/src/main/java/org/ggp/base/apps/server/states/StatesPanel.java
@@ -54,7 +54,7 @@ public class StatesPanel extends JPanel implements Observer {
             // moved off into a new thread
             int stepNum = stepCount;
             stepCount++;
-            boolean atEnd = (tabs.getSelectedIndex() == tabs.getTabCount()-1);
+            boolean atEnd = tabs.getSelectedIndex() == tabs.getTabCount()-1;
 
             for(int i = tabs.getTabCount(); i < stepNum; i++)
                 tabs.add(new Integer(i+1).toString(), new JPanel());

--- a/src/main/java/org/ggp/base/player/gamer/statemachine/random/RandomGamer.java
+++ b/src/main/java/org/ggp/base/player/gamer/statemachine/random/RandomGamer.java
@@ -34,7 +34,7 @@ public final class RandomGamer extends StateMachineGamer
         long start = System.currentTimeMillis();
 
         List<Move> moves = getStateMachine().getLegalMoves(getCurrentState(), getRole());
-        Move selection = (moves.get(new Random().nextInt(moves.size())));
+        Move selection = moves.get(new Random().nextInt(moves.size()));
 
         long stop = System.currentTimeMillis();
 

--- a/src/main/java/org/ggp/base/player/gamer/statemachine/sample/SampleSearchLightGamer.java
+++ b/src/main/java/org/ggp/base/player/gamer/statemachine/sample/SampleSearchLightGamer.java
@@ -73,7 +73,7 @@ public final class SampleSearchLightGamer extends StateMachineGamer
         long finishBy = timeout - 1000;
 
         List<Move> moves = theMachine.getLegalMoves(getCurrentState(), getRole());
-        Move selection = (moves.get(theRandom.nextInt(moves.size())));
+        Move selection = moves.get(theRandom.nextInt(moves.size()));
 
         // Shuffle the moves into a random order, so that when we find the first
         // move that doesn't give our opponent a forced win, we aren't always choosing

--- a/src/main/java/org/ggp/base/util/propnet/architecture/PropNet.java
+++ b/src/main/java/org/ggp/base/util/propnet/architecture/PropNet.java
@@ -141,14 +141,14 @@ public final class PropNet
         // Create a mapping from Body->Input.
         Map<List<GdlTerm>, Proposition> inputPropsByBody = new HashMap<List<GdlTerm>, Proposition>();
         for(Proposition inputProp : inputPropositions.values()) {
-            List<GdlTerm> inputPropBody = (inputProp.getName()).getBody();
+            List<GdlTerm> inputPropBody = inputProp.getName().getBody();
             inputPropsByBody.put(inputPropBody, inputProp);
         }
         // Use that mapping to map Input->Legal and Legal->Input
         // based on having the same Body proposition.
         for(Set<Proposition> legalProps : legalPropositions.values()) {
             for(Proposition legalProp : legalProps) {
-                List<GdlTerm> legalPropBody = (legalProp.getName()).getBody();
+                List<GdlTerm> legalPropBody = legalProp.getName().getBody();
                 if (inputPropsByBody.containsKey(legalPropBody)) {
                     Proposition inputProp = inputPropsByBody.get(legalPropBody);
                     legalInputMap.put(inputProp, legalProp);

--- a/src/main/java/org/ggp/base/util/prover/aima/AimaProver.java
+++ b/src/main/java/org/ggp/base/util/prover/aima/AimaProver.java
@@ -153,7 +153,7 @@ public final class AimaProver implements Prover
             isConstant &= isConstantRet.value;
             goals.removeFirst();
 
-            if (askOne && (results.size() > 0))
+            if (askOne && results.size() > 0)
             {
                 break;
             }
@@ -171,7 +171,7 @@ public final class AimaProver implements Prover
         {
             ask(goals, context, theta.compose(thetaPrime), cache, renamer, askOne, results, recursionHandler, isConstantRet);
             isConstant &= isConstantRet.value;
-            if (askOne && (results.size() > 0))
+            if (askOne && results.size() > 0)
             {
                 break;
             }
@@ -275,7 +275,7 @@ public final class AimaProver implements Prover
         }
 
         List<Substitution> cachedResults = fixedAnswerCache.get(sentence, varRenamedSentence);
-        isConstantRet.value = (cachedResults != null);
+        isConstantRet.value = cachedResults != null;
         if (cachedResults == null) {
             cachedResults = cache.get(sentence, varRenamedSentence);
         }

--- a/src/main/java/org/ggp/base/util/prover/aima/substitution/Substitution.java
+++ b/src/main/java/org/ggp/base/util/prover/aima/substitution/Substitution.java
@@ -35,7 +35,7 @@ public final class Substitution
     @Override
     public boolean equals(Object o)
     {
-        if ((o != null) && (o instanceof Substitution))
+        if (o != null && o instanceof Substitution)
         {
             Substitution substitution = (Substitution) o;
             return substitution.contents.equals(contents);

--- a/src/main/java/org/ggp/base/util/prover/aima/unifier/Unifier.java
+++ b/src/main/java/org/ggp/base/util/prover/aima/unifier/Unifier.java
@@ -25,7 +25,7 @@ public final class Unifier
     {
         if(x.equals(y))
             return true;
-        if ((x instanceof GdlConstant) && (y instanceof GdlConstant))
+        if (x instanceof GdlConstant && y instanceof GdlConstant)
         {
             if (!x.equals(y))
             {
@@ -42,7 +42,7 @@ public final class Unifier
             if (!unifyVariable((GdlVariable) y, x, theta))
                 return false;
         }
-        else if ((x instanceof GdlFunction) && (y instanceof GdlFunction))
+        else if (x instanceof GdlFunction && y instanceof GdlFunction)
         {
             GdlFunction xFunction = (GdlFunction) x;
             GdlFunction yFunction = (GdlFunction) y;
@@ -70,7 +70,7 @@ public final class Unifier
         {
             return unifyTerm(theta.get(var), x, theta);
         }
-        else if ((x instanceof GdlVariable) && theta.contains((GdlVariable) x))
+        else if (x instanceof GdlVariable && theta.contains((GdlVariable) x))
         {
             return unifyTerm(var, theta.get((GdlVariable) x), theta);
         }

--- a/src/main/java/org/ggp/base/util/statemachine/MachineState.java
+++ b/src/main/java/org/ggp/base/util/statemachine/MachineState.java
@@ -56,7 +56,7 @@ public class MachineState {
     @Override
     public boolean equals(Object o)
     {
-        if ((o != null) && (o instanceof MachineState))
+        if (o != null && o instanceof MachineState)
         {
             MachineState state = (MachineState) o;
             return state.getContents().equals(getContents());

--- a/src/main/java/org/ggp/base/util/statemachine/Move.java
+++ b/src/main/java/org/ggp/base/util/statemachine/Move.java
@@ -35,7 +35,7 @@ public class Move implements Serializable
     @Override
     public boolean equals(Object o)
     {
-        if ((o != null) && (o instanceof Move)) {
+        if (o != null && o instanceof Move) {
             Move move = (Move) o;
             return move.contents.equals(contents);
         }

--- a/src/main/java/org/ggp/base/util/statemachine/Role.java
+++ b/src/main/java/org/ggp/base/util/statemachine/Role.java
@@ -33,7 +33,7 @@ public class Role implements Serializable
     @Override
     public boolean equals(Object o)
     {
-        if ((o != null) && (o instanceof Role))
+        if (o != null && o instanceof Role)
         {
             Role role = (Role) o;
             return role.name.equals(name);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.