### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/external/JSON/JSONArray.java
+++ b/src/main/java/external/JSON/JSONArray.java
@@ -346,7 +346,7 @@ public class JSONArray {
      */
     public String join(String separator) throws JSONException {
         int len = length();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < len; i += 1) {
             if (i > 0) {
@@ -850,7 +850,7 @@ public class JSONArray {
             return "[]";
         }
         int i;
-        StringBuffer sb = new StringBuffer("[");
+        StringBuilder sb = new StringBuilder("[");
         if (len == 1) {
             sb.append(JSONObject.valueToString(this.myArrayList.get(0),
                     indentFactor, indent));

--- a/src/main/java/external/JSON/JSONObject.java
+++ b/src/main/java/external/JSON/JSONObject.java
@@ -1152,7 +1152,7 @@ public class JSONObject {
         String       hhhh;
         int          i;
         int          len = string.length();
-        StringBuffer sb = new StringBuffer(len + 4);
+        StringBuilder sb = new StringBuilder(len + 4);
 
         sb.append('"');
         for (i = 0; i < len; i += 1) {
@@ -1333,7 +1333,7 @@ public class JSONObject {
     public String toString() {
         try {
             Iterator<?>  keys = keys();
-            StringBuffer sb = new StringBuffer("{");
+            StringBuilder sb = new StringBuilder("{");
 
             while (keys.hasNext()) {
                 if (sb.length() > 1) {
@@ -1391,7 +1391,7 @@ public class JSONObject {
         Iterator<?>  keys = sortedKeys();
         int          newindent = indent + indentFactor;
         Object       object;
-        StringBuffer sb = new StringBuffer("{");
+        StringBuilder sb = new StringBuilder("{");
         if (length == 1) {
             object = keys.next();
             sb.append(quote(object.toString()));

--- a/src/main/java/external/JSON/JSONTokener.java
+++ b/src/main/java/external/JSON/JSONTokener.java
@@ -249,7 +249,7 @@ public class JSONTokener {
      */
     public String nextString(char quote) throws JSONException {
         char c;
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (;;) {
             c = next();
             switch (c) {
@@ -305,7 +305,7 @@ public class JSONTokener {
      * @return   A string.
      */
     public String nextTo(char delimiter) throws JSONException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (;;) {
             char c = next();
             if (c == delimiter || c == 0 || c == '\n' || c == '\r') {
@@ -327,7 +327,7 @@ public class JSONTokener {
      */
     public String nextTo(String delimiters) throws JSONException {
         char c;
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (;;) {
             c = next();
             if (delimiters.indexOf(c) >= 0 || c == 0 ||
@@ -374,7 +374,7 @@ public class JSONTokener {
          * formatting character.
          */
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
             sb.append(c);
             c = next();

--- a/src/main/java/org/ggp/base/apps/server/states/StatesPanel.java
+++ b/src/main/java/org/ggp/base/apps/server/states/StatesPanel.java
@@ -40,7 +40,7 @@ public class StatesPanel extends JPanel implements Observer {
                 sentences.add(sentence.toString());
             //The list of sentences is more useful when sorted alphabetically.
             Collections.sort(sentences);
-            StringBuffer sentencesList = new StringBuffer();
+            StringBuilder sentencesList = new StringBuilder();
             for(String sentence : sentences)
                 sentencesList.append(sentence).append("\n");
             JTextArea statesTextArea = new JTextArea(sentencesList.toString());

--- a/src/main/java/org/ggp/base/util/crypto/CanonicalJSON.java
+++ b/src/main/java/org/ggp/base/util/crypto/CanonicalJSON.java
@@ -55,7 +55,7 @@ public class CanonicalJSON {
                 while (i.hasNext()) t.add(i.next().toString());
                 Iterator<String> keys = t.iterator();
 
-                StringBuffer sb = new StringBuffer("{");
+                StringBuilder sb = new StringBuilder("{");
                 while (keys.hasNext()) {
                     if (sb.length() > 1) {
                         sb.append(',');
@@ -69,7 +69,7 @@ public class CanonicalJSON {
                 return sb.toString();
             } else if (x instanceof JSONArray) {
                 JSONArray theArray = (JSONArray)x;
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append("[");
                 int len = theArray.length();
                 for (int i = 0; i < len; i += 1) {

--- a/src/main/java/org/ggp/base/util/ui/GameStateRenderer.java
+++ b/src/main/java/org/ggp/base/util/ui/GameStateRenderer.java
@@ -122,9 +122,9 @@ public class GameStateRenderer {
     //========IOstring code========
     private static class IOString
     {
-        private StringBuffer buf;
+        private StringBuilder buf;
         public IOString(String s) {
-            buf = new StringBuffer(s);
+            buf = new StringBuilder(s);
         }
         public String getString() {
             return buf.toString();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.