### PR TITLE
 Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/main/java/org/ggp/base/apps/kiosk/games/BiddingTicTacToeCanvas.java
+++ b/src/main/java/org/ggp/base/apps/kiosk/games/BiddingTicTacToeCanvas.java
@@ -63,7 +63,7 @@ public class BiddingTicTacToeCanvas extends GameCanvas_FancyGrid {
         } else {
             int nScore = onScoreboard(xCell, yCell);
             if(nScore >= 0) {
-                CommonGraphics.fillWithString(g, "" + nScore, 1.2);
+                CommonGraphics.fillWithString(g, String.valueOf(nScore), 1.2);
             } else if(nScore == -2) {
                 CommonGraphics.fillWithString(g, "T", 1.2);
             }

--- a/src/main/java/org/ggp/base/apps/kiosk/games/CephalopodCanvas.java
+++ b/src/main/java/org/ggp/base/apps/kiosk/games/CephalopodCanvas.java
@@ -43,7 +43,7 @@ public class CephalopodCanvas extends GameCanvas_FancyGrid {
             g.setColor(Color.BLACK);
         }
 
-        CommonGraphics.fillWithString(g, "" + cellValue, 1.2);
+        CommonGraphics.fillWithString(g, String.valueOf(cellValue), 1.2);
     }
 
     @Override

--- a/src/main/java/org/ggp/base/apps/kiosk/games/FFACanvas.java
+++ b/src/main/java/org/ggp/base/apps/kiosk/games/FFACanvas.java
@@ -81,7 +81,7 @@ public class FFACanvas extends GameCanvas_FancyGrid {
             }
 
             g.setColor(myColor);
-            CommonGraphics.fillWithString(g, "" + score, 1.5);
+            CommonGraphics.fillWithString(g, String.valueOf(score), 1.5);
         } else {
             String cellType = cellFacts[4];
             if(!cellType.equals("b")) {

--- a/src/main/java/org/ggp/base/apps/kiosk/templates/GameCanvas_Chessboard.java
+++ b/src/main/java/org/ggp/base/apps/kiosk/templates/GameCanvas_Chessboard.java
@@ -39,6 +39,6 @@ public abstract class GameCanvas_Chessboard extends GameCanvas_FancyGrid {
 
     // This function only works properly when coordinates start at one.
     public final static String coordinateToLetter(int x) {
-        return "" + ((char) ('a' + x - 1));
+        return String.valueOf((char) ('a' + x - 1));
     }
 }

--- a/src/main/java/org/ggp/base/apps/research/Counter.java
+++ b/src/main/java/org/ggp/base/apps/research/Counter.java
@@ -19,7 +19,7 @@ public final class Counter implements Comparable<Counter>
 
     @Override
     public String toString() {
-        return "" + ((int)(getValue() * 1000.0)/1000.0);
+        return String.valueOf((int)(getValue() * 1000.0)/1000.0);
     }
 
     @Override

--- a/src/main/java/org/ggp/base/apps/research/WeightedAverage.java
+++ b/src/main/java/org/ggp/base/apps/research/WeightedAverage.java
@@ -28,7 +28,7 @@ public final class WeightedAverage implements Comparable<WeightedAverage>
 
     @Override
     public String toString() {
-        return "" + ((int)(getValue() * 1000.0)/1000.0) + " [" + getWeight() + "]";
+        return String.valueOf((int)(getValue() * 1000.0)/1000.0) + " [" + getWeight() + "]";
     }
 
     @Override

--- a/src/main/java/org/ggp/base/apps/server/states/StatesPanel.java
+++ b/src/main/java/org/ggp/base/apps/server/states/StatesPanel.java
@@ -57,9 +57,9 @@ public class StatesPanel extends JPanel implements Observer {
             boolean atEnd = (tabs.getSelectedIndex() == tabs.getTabCount()-1);
 
             for(int i = tabs.getTabCount(); i < stepNum; i++)
-                tabs.add(new Integer(i+1).toString(), new JPanel());
+                tabs.add(String.valueOf(i+1), new JPanel());
             tabs.setComponentAt(stepNum-1, statePanel);
-            tabs.setTitleAt(stepNum-1, new Integer(stepNum).toString());
+            tabs.setTitleAt(stepNum-1, String.valueOf(stepNum));
 
             if(atEnd) {
                 tabs.setSelectedIndex(tabs.getTabCount()-1);

--- a/src/main/java/org/ggp/base/apps/server/visualization/VisualizationPanel.java
+++ b/src/main/java/org/ggp/base/apps/server/visualization/VisualizationPanel.java
@@ -115,9 +115,9 @@ public final class VisualizationPanel extends JPanel implements Observer
                     boolean atEnd = (tabs.getSelectedIndex() == tabs.getTabCount()-1);
                     try {
                         for(int i = tabs.getTabCount(); i < stepNum; i++)
-                            tabs.add(new Integer(i+1).toString(), new JPanel());
+                            tabs.add(String.valueOf(i+1), new JPanel());
                         tabs.setComponentAt(stepNum-1, newPanel);
-                        tabs.setTitleAt(stepNum-1, new Integer(stepNum).toString());
+                        tabs.setTitleAt(stepNum-1, String.valueOf(stepNum));
 
                         if(atEnd) {
                             tabs.setSelectedIndex(tabs.getTabCount()-1);

--- a/src/main/java/org/ggp/base/player/proxy/ProxyGamePlayer.java
+++ b/src/main/java/org/ggp/base/player/proxy/ProxyGamePlayer.java
@@ -103,7 +103,7 @@ public final class ProxyGamePlayer extends Thread implements Subject
             processArgs.add(System.getProperty("java.class.path"));
             processArgs.add("org.ggp.base.player.proxy.ProxyGamePlayerClient");
             processArgs.add(gamerName);
-            processArgs.add("" + clientListener.getLocalPort());
+            processArgs.add(String.valueOf(clientListener.getLocalPort()));
             if(GamerConfiguration.runningOnLinux()) {
                 processArgs.add(0, "nice");
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.