### PR TITLE
Add basic support for random roles.

### DIFF
--- a/src/main/java/org/ggp/base/server/GameServer.java
+++ b/src/main/java/org/ggp/base/server/GameServer.java
@@ -25,6 +25,7 @@ import org.ggp.base.server.threads.PreviewRequestThread;
 import org.ggp.base.server.threads.RandomPlayRequestThread;
 import org.ggp.base.server.threads.StartRequestThread;
 import org.ggp.base.server.threads.StopRequestThread;
+import org.ggp.base.util.gdl.grammar.GdlPool;
 import org.ggp.base.util.match.Match;
 import org.ggp.base.util.match.MatchPublisher;
 import org.ggp.base.util.observer.Event;
@@ -67,6 +68,12 @@ public final class GameServer extends Thread implements Subject
 
         playerGetsUnlimitedTime = new boolean[hosts.size()];
         playerPlaysRandomly = new boolean[hosts.size()];
+        List<Role> roles = Role.computeRoles(match.getGame().getRules());
+        for (int r = 0; r < roles.size(); r++) {
+            if (roles.get(r).getName() == GdlPool.RANDOM) {
+                playerPlaysRandomly[r] = true;
+            }
+        }
 
         stateMachine = new ProverStateMachine();
         stateMachine.initialize(match.getGame().getRules());

--- a/src/main/java/org/ggp/base/util/gdl/grammar/GdlPool.java
+++ b/src/main/java/org/ggp/base/util/gdl/grammar/GdlPool.java
@@ -52,7 +52,7 @@ public final class GdlPool
     // game-specific constants are case-sensitive or not. These special keywords are never
     // sent over the network in PLAY requests and responses, so this should be safe.
     public static final ImmutableSet<String> KEYWORDS = ImmutableSet.of(
-            "init","true","next","role","does","goal","legal","terminal","base","input","_");
+            "init","true","next","role","does","goal","legal","terminal","base","input","random","_");
     public static final GdlConstant BASE = getConstant("base");
     public static final GdlConstant DOES = getConstant("does");
     public static final GdlConstant GOAL = getConstant("goal");
@@ -60,6 +60,7 @@ public final class GdlPool
     public static final GdlConstant INPUT = getConstant("input");
     public static final GdlConstant LEGAL = getConstant("legal");
     public static final GdlConstant NEXT = getConstant("next");
+    public static final GdlConstant RANDOM = getConstant("random");
     public static final GdlConstant ROLE = getConstant("role");
     public static final GdlConstant TERMINAL = getConstant("terminal");
     public static final GdlConstant TRUE = getConstant("true");


### PR DESCRIPTION
This tells the GameServer to pick random moves for roles named "random", and makes sure the role name won't be obfuscated.

This does not change any of the UIs around player selection, so it will still display requests for player selection for random roles that will then be ignored. We may prefer to fix that before making this change. However, that may be easier if GameServer is substantially refactored in a way that breaks downstream users (e.g. collecting player info as a Role-keyed Map instead of a List).

This does not include the (gdl random) proposal for activating this behavior.